### PR TITLE
Update apptx.yaml

### DIFF
--- a/usvc/apptx.yaml
+++ b/usvc/apptx.yaml
@@ -817,7 +817,7 @@ spec:
     spec:
       containers:
       - name: user
-        image: image-registry.openshift-image-registry.svc:5000/sock-shop/user
+        image: quay.io/daniel_casali/usvc-user
         resources:
           limits:
             cpu: 300m


### PR DESCRIPTION
Changed line 820, from
        image: image-registry.openshift-image-registry.svc:5000/sock-shop/user
to
	quay.io/daniel_casali/usvc-user

Updated documentation https://nas01.tallpaul.net/wordpress/2024/11/sock-shop-lab/ as below
Important Note

There has been a recent change to an opensource component that is required by the sock-shop application. On Sunday 10th November, I noticed that the openzipkin component had changed, causing the build of the container to fail this . The change must have taken place since the end of October, when I last recorded the demonstration. The current output from the podman build command is below. 

For this reason, please now skip to chapter 5. Building-a-.NET-Service-from-a-UBI-image

I will modify the application yaml file to pull the prebuilt Go User Application container from Quay.io -----------------------------------